### PR TITLE
Some plugins recovered

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -539,25 +539,32 @@ require('lazy').setup({
           --  Most Language Servers support renaming across files, etc.
           map('grn', vim.lsp.buf.rename, '[R]e[n]ame')
 
+          vim.keymap.set('n', '<S-F6>', ':lua vim.lsp.buf.rename()<CR>') -- , {silent = true}) -- Rename variable
+          vim.keymap.set('n', '<leader>ff', ':lua vim.lsp.buf.format()<CR>', { silent = true }) -- Format files
+
           -- Execute a code action, usually your cursor needs to be on top of an error
           -- or a suggestion from your LSP for this to activate.
           map('gra', vim.lsp.buf.code_action, '[G]oto Code [A]ction', { 'n', 'x' })
 
           -- Find references for the word under your cursor.
           map('grr', require('telescope.builtin').lsp_references, '[G]oto [R]eferences')
+          map('gR', require('telescope.builtin').lsp_references, '[G]oto [R]eferences')
 
           -- Jump to the implementation of the word under your cursor.
           --  Useful when your language has ways of declaring types without an actual implementation.
           map('gri', require('telescope.builtin').lsp_implementations, '[G]oto [I]mplementation')
+          map('gI', require('telescope.builtin').lsp_implementations, '[G]oto [I]mplementation')
 
           -- Jump to the definition of the word under your cursor.
           --  This is where a variable was first declared, or where a function is defined, etc.
           --  To jump back, press <C-t>.
           map('grd', require('telescope.builtin').lsp_definitions, '[G]oto [D]efinition')
+          map('gd', require('telescope.builtin').lsp_definitions, '[G]oto [D]efinition')
 
           -- WARN: This is not Goto Definition, this is Goto Declaration.
           --  For example, in C this would take you to the header.
           map('grD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')
+          map('gD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')
 
           -- Fuzzy find all the symbols in your current document.
           --  Symbols are things like variables, functions, types, etc.
@@ -571,6 +578,7 @@ require('lazy').setup({
           --  Useful when you're not sure what type a variable is and you want to see
           --  the definition of its *type*, not where it was *defined*.
           map('grt', require('telescope.builtin').lsp_type_definitions, '[G]oto [T]ype Definition')
+          map('gT', require('telescope.builtin').lsp_type_definitions, '[G]oto [T]ype Definition')
 
           -- This function resolves a difference between neovim nightly (version 0.11) and stable (version 0.10)
           ---@param client vim.lsp.Client
@@ -984,7 +992,7 @@ require('lazy').setup({
   --    This is the easiest way to modularize your config.
   --
   --  Uncomment the following line and add your plugins to `lua/custom/plugins/*.lua` to get going.
-  -- { import = 'custom.plugins' },
+  { import = 'custom.plugins' },
   --
   -- For additional information with loading, sourcing and examples see `:help lazy.nvim-🔌-plugin-spec`
   -- Or use telescope!
@@ -1014,3 +1022,67 @@ require('lazy').setup({
 
 -- The line beneath this is called `modeline`. See `:help modeline`
 -- vim: ts=2 sts=2 sw=2 et
+
+-- Keybinds to make split navigation easier.
+--  Use CTRL+<hjkl> to switch between windows
+--
+--  See `:help wincmd` for a list of all window commands
+vim.keymap.set('n', '<C-h>', '<C-w><C-h>', { desc = 'Move focus to the left window' })
+vim.keymap.set('n', '<C-l>', '<C-w><C-l>', { desc = 'Move focus to the right window' })
+vim.keymap.set('n', '<C-j>', '<C-w><C-j>', { desc = 'Move focus to the lower window' })
+vim.keymap.set('n', '<C-k>', '<C-w><C-k>', { desc = 'Move focus to the upper window' })
+
+-- NOTE: Some terminals have colliding keymaps or are not able to send distinct keycodes
+-- vim.keymap.set("n", "<C-S-h>", "<C-w>H", { desc = "Move window to the left" })
+-- vim.keymap.set("n", "<C-S-l>", "<C-w>L", { desc = "Move window to the right" })
+-- vim.keymap.set("n", "<C-S-j>", "<C-w>J", { desc = "Move window to the lower" })
+-- vim.keymap.set("n", "<C-S-k>", "<C-w>K", { desc = "Move window to the upper" })
+
+-- keymaps for splits and tabs
+-- window management
+vim.keymap.set('n', '<leader>sv', '<C-w>v', { desc = '[S]plit Window [V]ertically' }) -- split window vertically
+vim.keymap.set('n', '<leader>s-', '<C-w>s', { desc = '[S]plit Window [-]Horizontally' }) -- split window horizontally
+vim.keymap.set('n', '<leader>se', '<C-w>=', { desc = 'Make [S]plit Windows [E]qual' }) -- make split windows equal width & height
+vim.keymap.set('n', '<leader>sx', ':close<CR>', { desc = 'Close Split Window' }) -- close current split window
+-- tabs
+vim.keymap.set('n', '<leader>to', ':tabnew<CR>') -- open new tab
+vim.keymap.set('n', '<leader>tx', ':tabclose<CR>') -- close current tab
+vim.keymap.set('n', '<leader>tn', ':tabn<CR>') --  go to next tab
+vim.keymap.set('n', '<leader>tp', ':tabp<CR>') --  go to previous tab
+
+-- Setup nvterm with pcall to handle potential errors
+vim.keymap.set('n', '<leader>tt', function()
+  local ok, nvterm = pcall(require, 'nvterm.terminal')
+  if ok then
+    nvterm.toggle 'horizontal'
+  else
+    vim.notify('nvterm not available', vim.log.levels.WARN)
+  end
+end, { silent = true, desc = 'Toggle horizontal terminal' })
+
+vim.keymap.set('n', '<leader>tf', function()
+  local ok, nvterm = pcall(require, 'nvterm.terminal')
+  if ok then
+    nvterm.toggle 'float'
+  else
+    vim.notify('nvterm not available', vim.log.levels.WARN)
+  end
+end, { silent = true, desc = 'Toggle floating terminal' })
+
+-- keymaps for NvimTree
+vim.keymap.set('n', '<M-1>', ':NvimTreeToggle<CR>', { silent = true }) -- open file explorer
+vim.keymap.set('n', '<M-2>', ':NvimTreeFindFile<CR>', { silent = true }) -- open file explorer
+vim.keymap.set('n', '<leader>fx', ':NvimTreeOpen<CR>') -- open file explorer
+
+-- keymaps for Aerial
+vim.keymap.set('n', '<M-3>', ':AerialToggle!<CR>', { silent = true }) -- open aerial
+vim.keymap.set('n', '<M-4>', ':AerialToggle<CR>', { silent = true }) -- open aerial
+
+-- keumaps for CtrlS
+vim.g.ctrlsf_default_root = 'project'
+vim.keymap.set('n', '<leader>fa', '<Plug>CtrlSFPrompt', { desc = '[F]ind in [A]ll files', silent = true })
+vim.keymap.set('n', '<leader>fg', ':CtrlSFToggle<CR>', { desc = '[F]ind window To[g]gle', silent = true })
+vim.keymap.set('n', '<M-8>', ':CtrlSF<CR>', { silent = true })
+vim.keymap.set('v', '<M-9>', '<Plug>CtrlSFVwordExec', { silent = true })
+
+require 'hydras'

--- a/lua/config/nvtree.lua
+++ b/lua/config/nvtree.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+local api = require('nvim-tree.api')
+
+-- local function opts(desc)
+-- return { desc = 'nvim-tree: ' .. desc, buffer = bufnr, noremap = true, silent = true, nowait = true }
+-- end
+
+local function my_on_attach(bufnr)
+  api.config.mappings.default_on_attach(bufnr)
+end
+
+function M.setup()
+  require("nvim-tree").setup({
+    on_attach = my_on_attach,
+  })
+end
+return M

--- a/lua/custom/plugins/aerial.lua
+++ b/lua/custom/plugins/aerial.lua
@@ -1,0 +1,9 @@
+return {
+  'stevearc/aerial.nvim',
+  opts = {},
+  -- Optional dependencies
+  dependencies = {
+     "nvim-treesitter/nvim-treesitter",
+     "nvim-tree/nvim-web-devicons"
+  },
+}

--- a/lua/custom/plugins/hydra.lua
+++ b/lua/custom/plugins/hydra.lua
@@ -1,0 +1,3 @@
+return {
+	'anuvyklack/hydra.nvim',
+}

--- a/lua/custom/plugins/init.lua
+++ b/lua/custom/plugins/init.lua
@@ -2,4 +2,9 @@
 --  I promise not to create any merge conflicts in this directory :)
 --
 -- See the kickstart.nvim README for more information
-return {}
+return {
+	'christoomey/vim-tmux-navigator',
+	'tpope/vim-fugitive',
+	'tversteeg/registers.nvim',
+	'dyng/ctrlsf.vim',
+}

--- a/lua/custom/plugins/nvterm.lua
+++ b/lua/custom/plugins/nvterm.lua
@@ -1,0 +1,31 @@
+return {
+  "NvChad/nvterm",
+  config = function()
+    require("nvterm").setup({
+      terminals = {
+        shell = vim.o.shell,
+        list = {},
+        type_opts = {
+          float = {
+            relative = 'editor',
+            row = 0.3,
+            col = 0.25,
+            width = 0.5,
+            height = 0.4,
+            border = "single",
+          },
+          horizontal = { location = "rightbelow", split_ratio = .3, },
+          vertical = { location = "rightbelow", split_ratio = .5 },
+        }
+      },
+      behavior = {
+        autoclose_on_quit = {
+          enabled = false,
+          confirm = true,
+        },
+        close_on_exit = true,
+        auto_insert = true,
+      },
+    })
+  end,
+}

--- a/lua/custom/plugins/nvtree.lua
+++ b/lua/custom/plugins/nvtree.lua
@@ -1,0 +1,9 @@
+return {
+  "nvim-tree/nvim-tree.lua",
+  dependencies = {
+    "nvim-tree/nvim-web-devicons",
+  },
+  config = function()
+    require("config.nvtree").setup()
+  end,
+}

--- a/lua/hydras.lua
+++ b/lua/hydras.lua
@@ -1,0 +1,115 @@
+local Hydra = require 'hydra'
+
+local hint = [[
+  ^ ^        Options
+  ^
+  _v_ %{ve} virtual edit
+  _i_ %{list} invisible characters  
+  _w_ %{wrap} wrap
+  _c_ %{cul} cursor line
+  _n_ %{nu} number
+  _r_ %{rnu} relative number
+  ^
+       ^^^^                _<Esc>_
+]]
+
+Hydra {
+  name = 'Options',
+  hint = hint,
+  config = {
+    color = 'amaranth',
+    invoke_on_body = true,
+    hint = {
+      border = 'rounded',
+      position = 'middle',
+    },
+  },
+  mode = { 'n', 'x' },
+  body = '<leader>p',
+  heads = {
+    {
+      'n',
+      function()
+        if vim.o.number == true then
+          vim.o.number = false
+        else
+          vim.o.number = true
+        end
+      end,
+      { desc = 'number' },
+    },
+    {
+      'r',
+      function()
+        if vim.o.relativenumber == true then
+          vim.o.relativenumber = false
+        else
+          vim.o.number = true
+          vim.o.relativenumber = true
+        end
+      end,
+      { desc = 'relativenumber' },
+    },
+    {
+      'v',
+      function()
+        if vim.o.virtualedit == 'all' then
+          vim.o.virtualedit = 'block'
+        else
+          vim.o.virtualedit = 'all'
+        end
+      end,
+      { desc = 'virtualedit' },
+    },
+    {
+      'i',
+      function()
+        if vim.o.list == true then
+          vim.o.list = false
+        else
+          vim.o.list = true
+        end
+      end,
+      { desc = 'show invisible' },
+    },
+    {
+      'w',
+      function()
+        if vim.o.wrap ~= true then
+          vim.o.wrap = true
+          -- Dealing with word wrap:
+          -- If cursor is inside very long line in the file than wraps
+          -- around several rows on the screen, then 'j' key moves you to
+          -- the next line in the file, but not to the next row on the
+          -- screen under your previous position as in other editors. These
+          -- bindings fixes this.
+          --[[
+            vim.keymap.set('n', 'k', function() return vim.v.count > 0 and 'k' or 'gk' end,
+                                     { expr = true, desc = 'k or gk' })
+            vim.keymap.set('n', 'j', function() return vim.v.count > 0 and 'j' or 'gj' end,
+                                     { expr = true, desc = 'j or gj' })
+	--]]
+        else
+          vim.o.wrap = false
+          --[[
+            vim.keymap.del('n', 'k')
+            vim.keymap.del('n', 'j')
+	--]]
+        end
+      end,
+      { desc = 'wrap' },
+    },
+    {
+      'c',
+      function()
+        if vim.o.cursorline == true then
+          vim.o.cursorline = false
+        else
+          vim.o.cursorline = true
+        end
+      end,
+      { desc = 'cursor line' },
+    },
+    { '<Esc>', nil, { exit = true } },
+  },
+}


### PR DESCRIPTION
This pull request introduces several enhancements to the Neovim configuration, focusing on new keybindings, plugin integrations, and improved modularity. The most notable changes include adding keymaps for window and tab navigation, integrating new plugins (e.g., `aerial.nvim`, `nvterm`), and enabling custom configurations for plugins like `nvim-tree` and `hydra.nvim`.

### Keymap Enhancements:
* Added keybindings for easier split navigation (`<C-h>`, `<C-l>`, `<C-j>`, `<C-k>`), window management (`<leader>sv`, `<leader>s-`, `<leader>se`, `<leader>sx`), and tab navigation (`<leader>to`, `<leader>tx`, `<leader>tn`, `<leader>tp`).
* Introduced keymaps for toggling terminals (`<leader>tt`, `<leader>tf`), file explorer (`<M-1>`, `<leader>fx`), and Aerial outline (`<M-3>`, `<M-4>`).

### Plugin Integrations:
* Added and configured the `nvterm` plugin for terminal management, supporting horizontal, floating, and vertical terminal toggles.
* Integrated `aerial.nvim` for code outline navigation with dependencies on `nvim-treesitter` and `nvim-web-devicons`.
* Added `hydra.nvim` for creating custom keybinding menus with a sample configuration for toggling Neovim options. [[1]](diffhunk://#diff-5c4f0441b0d4a9a07eaee4ac79293f0cac5c3f74c3a7725061e29d78d0955dd7R1-R3) [[2]](diffhunk://#diff-9e35183f3eface6dabe9cedfdc93fde5678fe4639a3b7d4e9ecfc139f6f1c85aR1-R115)

### LSP Keymap Improvements:
* Extended keybindings for LSP actions, such as renaming (`<S-F6>`), formatting (`<leader>ff`), and navigating definitions, references, and type definitions (`gd`, `gR`, `gT`, etc.). [[1]](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7R542-R567) [[2]](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7R581)

### Modular Configuration:
* Enabled modular plugin configuration by uncommenting the `custom.plugins` import in `init.lua`.
* Added custom plugin configurations for `nvim-tree` and `aerial.nvim` in dedicated files. [[1]](diffhunk://#diff-8e6890f9b211fd8013de441b2e30d67af26d44836e011421b56138a6f1a6836bR1-R18) [[2]](diffhunk://#diff-7478c9f65f6e1d55e56713ec9635359a45c7c4e56db8217a732587e1219f15f8R1-R9)

### Additional Plugins:
* Included new plugins such as `vim-tmux-navigator`, `vim-fugitive`, `registers.nvim`, and `ctrlsf.vim` for enhanced navigation, Git integration, and search functionality.

