### PR TITLE
Adding the capability to enable or disable copilot by using an env va…

### DIFF
--- a/lua/custom/plugins/copilot-chat.lua
+++ b/lua/custom/plugins/copilot-chat.lua
@@ -1,6 +1,7 @@
 return {
   {
     'CopilotC-Nvim/CopilotChat.nvim',
+    enabled = vim.fn.getenv("NVIM_COPILOT") == "true",
     dependencies = {
       { 'zbirenbaum/copilot.lua' },
       { 'nvim-lua/plenary.nvim', branch = 'master' }, -- for curl, log and async functions

--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -1,5 +1,6 @@
 return {
 	"zbirenbaum/copilot.lua",
+	enabled = vim.fn.getenv("NVIM_COPILOT") == "true",
 	cmd = "Copilot",
 	event = "InsertEnter",
 	config = function()


### PR DESCRIPTION
This pull request introduces a conditional enabling of Copilot plugins based on the `NVIM_COPILOT` environment variable. This ensures that the plugins are only activated when explicitly configured.

Key changes:

**Conditional plugin activation:**
* [`lua/custom/plugins/copilot-chat.lua`](diffhunk://#diff-a7703b228d236fe67f19317d7ca2d53b8c4301b67d146d606bf8bc16e5f8c69fR4): Added a condition to enable the `CopilotChat.nvim` plugin only if the `NVIM_COPILOT` environment variable is set to `"true"`.
* [`lua/custom/plugins/copilot.lua`](diffhunk://#diff-9bcb292b7ac1268ba32febbc3c029b5b2a63545412885123d03375ecb96f0f8cR3): Added a similar condition to enable the `copilot.lua` plugin based on the `NVIM_COPILOT` environment variable.