### PR TITLE
Added avante plugin - optional based on env variable

### DIFF
--- a/lua/custom/plugins/avante.lua
+++ b/lua/custom/plugins/avante.lua
@@ -1,0 +1,68 @@
+return {
+  'yetone/avante.nvim',
+  enabled = vim.fn.getenv 'NVIM_AVANTE' == 'true',
+  event = 'VeryLazy',
+  version = false, -- Never set this value to "*"! Never!
+  opts = {
+    -- add any opts here
+    -- for example
+    -- add any opts here
+    -- for example
+    provider = 'copilot',
+    claude = {
+      model = 'claude-3-7-sonnet-latest',
+      timeout = 30000, -- Timeout in milliseconds
+      temperature = 0,
+      max_tokens = 64000,
+    },
+    openai = {
+      endpoint = 'https://api.openai.com/v1',
+      model = 'codex-mini-latest', -- your desired model (or use gpt-4o, etc.)
+      timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
+      temperature = 0,
+      max_completion_tokens = 100000, -- Increase this to include reasoning tokens (for reasoning models)
+      --reasoning_effort = "medium", -- low|medium|high, only used for reasoning models
+    },
+  },
+  -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`
+  build = 'make',
+  -- build = "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false" -- for windows
+  dependencies = {
+    'nvim-treesitter/nvim-treesitter',
+    'stevearc/dressing.nvim',
+    'nvim-lua/plenary.nvim',
+    'MunifTanjim/nui.nvim',
+    --- The below dependencies are optional,
+    'echasnovski/mini.pick', -- for file_selector provider mini.pick
+    'nvim-telescope/telescope.nvim', -- for file_selector provider telescope
+    'hrsh7th/nvim-cmp', -- autocompletion for avante commands and mentions
+    'ibhagwan/fzf-lua', -- for file_selector provider fzf
+    'nvim-tree/nvim-web-devicons', -- or echasnovski/mini.icons
+    'zbirenbaum/copilot.lua', -- for providers='copilot'
+    {
+      -- support for image pasting
+      'HakonHarnes/img-clip.nvim',
+      event = 'VeryLazy',
+      opts = {
+        -- recommended settings
+        default = {
+          embed_image_as_base64 = false,
+          prompt_for_file_name = false,
+          drag_and_drop = {
+            insert_mode = true,
+          },
+          -- required for Windows users
+          use_absolute_path = true,
+        },
+      },
+    },
+    {
+      -- Make sure to set this up properly if you have lazy=true
+      'MeanderingProgrammer/render-markdown.nvim',
+      opts = {
+        file_types = { 'markdown', 'Avante' },
+      },
+      ft = { 'markdown', 'Avante' },
+    },
+  },
+}


### PR DESCRIPTION
This pull request adds a new plugin configuration for `avante.nvim` in the `lua/custom/plugins/avante.lua` file. The configuration includes setup options, dependencies, and build instructions for the plugin, enabling advanced features such as AI model integration, file selection providers, and markdown rendering.

### Plugin addition and configuration:

* Added `avante.nvim` plugin with support for AI models (`claude` and `openai`) and detailed configuration options, including timeout, temperature, and token limits.
* Included dependencies for enhanced functionality, such as file selection providers (`mini.pick`, `telescope`, `fzf`), autocompletion (`nvim-cmp`), and Copilot integration (`copilot.lua`).

### Additional features:

* Integrated support for image pasting with `img-clip.nvim`, including drag-and-drop functionality and Windows-specific settings.
* Added markdown rendering capabilities with `render-markdown.nvim`, configured for `markdown` and `Avante` file types.


