### PR TITLE
Fixed copilot model for avante

### DIFF
--- a/lua/custom/plugins/avante.lua
+++ b/lua/custom/plugins/avante.lua
@@ -24,7 +24,7 @@ return {
       --reasoning_effort = "medium", -- low|medium|high, only used for reasoning models
     },
     copilot = {
-      model = 'claude-3-7-sonnet-latest',
+      model = 'claude-3.7-sonnet', -- Default model to use for copilot
     },
   },
   -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`


### PR DESCRIPTION
This pull request includes a small change to the `lua/custom/plugins/avante.lua` file. The change updates the default model used for Copilot to `claude-3.7-sonnet` for improved clarity and consistency.