### PR TITLE
Added some new key mappings for block movement and Telescope

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -429,6 +429,7 @@ require('lazy').setup({
       vim.keymap.set('n', '<leader>sh', builtin.help_tags, { desc = '[S]earch [H]elp' })
       vim.keymap.set('n', '<leader>sk', builtin.keymaps, { desc = '[S]earch [K]eymaps' })
       vim.keymap.set('n', '<leader>sf', builtin.find_files, { desc = '[S]earch [F]iles' })
+      vim.keymap.set('n', '<leader>sb', builtin.buffers, { desc = '[S]earch Files ([B]uffers)' })
       vim.keymap.set('n', '<leader>ss', builtin.builtin, { desc = '[S]earch [S]elect Telescope' })
       vim.keymap.set('n', '<leader>sw', builtin.grep_string, { desc = '[S]earch current [W]ord' })
       vim.keymap.set('n', '<leader>sg', builtin.live_grep, { desc = '[S]earch by [G]rep' })
@@ -436,6 +437,7 @@ require('lazy').setup({
       vim.keymap.set('n', '<leader>sr', builtin.resume, { desc = '[S]earch [R]esume' })
       vim.keymap.set('n', '<leader>s.', builtin.oldfiles, { desc = '[S]earch Recent Files ("." for repeat)' })
       vim.keymap.set('n', '<leader><leader>', builtin.buffers, { desc = '[ ] Find existing buffers' })
+      vim.keymap.set('n', '<leader>sa', '<cmd> Telescope find_files follow=true no_ignore=true hidden=true <CR>', { desc = '[S]earch [A]ll Files' })
 
       -- Slightly advanced example of overriding default behavior and theme
       vim.keymap.set('n', '<leader>/', function()
@@ -1101,3 +1103,9 @@ vim.keymap.set({ 'n', 'v' }, '<leader>cr', '<cmd>CopilotChatRefactor<CR>', { des
 vim.keymap.set({ 'n', 'v' }, '<leader>cv', '<cmd>CopilotChatReview<CR>', { desc = '[C]opilot Chat Re[V]iew', silent = true })
 vim.keymap.set({ 'n', 'v' }, '<leader>co', '<cmd>CopilotChatOptimize<CR>', { desc = '[C]opilot Chat [O]ptimize', silent = true })
 vim.keymap.set({ 'n', 'v' }, '<leader>ct', '<cmd>CopilotChatTests<CR>', { desc = '[C]opilot Chat [T]ests', silent = true })
+
+-- Block movement keymaps
+vim.keymap.set('v', 'J', ":m '>+1<CR>gv=gv")
+vim.keymap.set('v', 'K', ":m '<-2<CR>gv=gv")
+vim.keymap.set('v', '<', '<gv')
+vim.keymap.set('v', '>', '>gv')

--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -10,7 +10,7 @@ return {
         auto_trigger = true,
         debounce = 75,
         keymap = {
-          accept = '<Tab>',
+          accept = '<M-CR>',
           accept_word = '<M-j>',
           accept_line = '<M-l>',
           next = '<M-]>',


### PR DESCRIPTION
This pull request introduces several updates to the Neovim configuration, focusing on enhancing key mappings for usability and improving Copilot plugin integration. The most important changes include new key mappings for searching and block movement, as well as a modification to the Copilot accept keybinding.

### Key mapping enhancements:

* Added new search key mappings to Telescope:
  - `<leader>sb`: Search open buffers.
  - [`<leader>sa`](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7R432-R440): Search all files, including hidden and ignored files. (`init.lua`, [init.luaR432-R440](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7R432-R440))

* Introduced block movement key mappings in visual mode:
  - `J`: Move selected block down.
  - `K`: Move selected block up.
  - `<`: Indent block left.
  - [`>`](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7R1106-R1111): Indent block right. (`init.lua`, [init.luaR1106-R1111](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7R1106-R1111))

### Copilot plugin updates:

* Changed the keybinding for accepting suggestions from `<Tab>` to `<M-CR>` (Meta + Enter) to prevent conflicts with other mappings. (`lua/custom/plugins/copilot.lua`, [lua/custom/plugins/copilot.luaL13-R13](diffhunk://#diff-9bcb292b7ac1268ba32febbc3c029b5b2a63545412885123d03375ecb96f0f8cL13-R13))