### PR TITLE
Added plugin to use Claude Code in nvim

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1109,3 +1109,7 @@ vim.keymap.set('v', 'J', ":m '>+1<CR>gv=gv")
 vim.keymap.set('v', 'K', ":m '<-2<CR>gv=gv")
 vim.keymap.set('v', '<', '<gv')
 vim.keymap.set('v', '>', '>gv')
+
+vim.keymap.set('n', '<leader>lc', '<cmd>ClaudeCode<CR>', { desc = 'C[l]aude [C]ode' })
+vim.keymap.set('n', '<leader>ln', '<cmd>ClaudeCodeContinue<CR>', { desc = 'C[l]aude Code Co[n]tinue' })
+vim.keymap.set('n', '<leader>lr', '<cmd>ClaudeCodeResume<CR>', { desc = 'C[l]aude Code [R]esume' })

--- a/lua/custom/plugins/claude-code.lua
+++ b/lua/custom/plugins/claude-code.lua
@@ -1,0 +1,60 @@
+return {
+  'greggh/claude-code.nvim',
+  enabled = vim.fn.getenv 'PROJECT_CONTEXT' == 'personal',
+  dependencies = {
+    'nvim-lua/plenary.nvim', -- Required for git operations
+  },
+  config = function()
+    require('claude-code').setup {
+      -- Terminal window settings
+      window = {
+        split_ratio = 0.4, -- Percentage of screen for the terminal window (height for horizontal, width for vertical splits)
+        position = 'botright', -- Position of the window: "botright", "topleft", "vertical", "rightbelow vsplit", etc.
+        enter_insert = true, -- Whether to enter insert mode when opening Claude Code
+        hide_numbers = true, -- Hide line numbers in the terminal window
+        hide_signcolumn = true, -- Hide the sign column in the terminal window
+      },
+      -- File refresh settings
+      refresh = {
+        enable = true, -- Enable file change detection
+        updatetime = 100, -- updatetime when Claude Code is active (milliseconds)
+        timer_interval = 1000, -- How often to check for file changes (milliseconds)
+        show_notifications = true, -- Show notification when files are reloaded
+      },
+      -- Git project settings
+      git = {
+        use_git_root = true, -- Set CWD to git root when opening Claude Code (if in git project)
+      },
+      -- Shell-specific settings
+      shell = {
+        separator = '&&', -- Command separator used in shell commands
+        pushd_cmd = 'pushd', -- Command to push directory onto stack (e.g., 'pushd' for bash/zsh, 'enter' for nushell)
+        popd_cmd = 'popd', -- Command to pop directory from stack (e.g., 'popd' for bash/zsh, 'exit' for nushell)
+      },
+      -- Command settings
+      command = 'claude', -- Command used to launch Claude Code
+      -- Command variants
+      command_variants = {
+        -- Conversation management
+        continue = '--continue', -- Resume the most recent conversation
+        resume = '--resume', -- Display an interactive conversation picker
+
+        -- Output options
+        verbose = '--verbose', -- Enable verbose logging with full turn-by-turn output
+      },
+      -- Keymaps
+      keymaps = {
+        toggle = {
+          normal = '<C-,>', -- Normal mode keymap for toggling Claude Code, false to disable
+          terminal = '<C-,>', -- Terminal mode keymap for toggling Claude Code, false to disable
+          variants = {
+            continue = '<leader>cC', -- Normal mode keymap for Claude Code with continue flag
+            verbose = '<leader>cV', -- Normal mode keymap for Claude Code with verbose flag
+          },
+        },
+        window_navigation = true, -- Enable window navigation keymaps (<C-h/j/k/l>)
+        scrolling = true, -- Enable scrolling keymaps (<C-f/b>) for page up/down
+      },
+    }
+  end,
+}


### PR DESCRIPTION


This pull request introduces a new plugin, `claude-code.nvim`, to enhance productivity by integrating Claude Code features into the Neovim setup. It also adds key mappings to streamline interaction with the plugin. The most important changes include the addition of the plugin configuration and the creation of new key mappings for accessing Claude Code functionalities.

### Plugin integration:

* [`lua/custom/plugins/claude-code.lua`](diffhunk://#diff-71c6a272f3f76fb1b19900eedbf979e3c1d25c1da52f900878b48a4e9c3240fbR1-R60): Added configuration for the `claude-code.nvim` plugin, including settings for terminal window behavior, file refresh options, Git integration, shell commands, and key mappings for toggling and navigating the Claude Code interface.

### Key mappings:

* [`init.lua`](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7R1112-R1115): Added new key mappings (`<leader>lc`, `<leader>ln`, `<leader>lr`) for accessing Claude Code commands (`ClaudeCode`, `ClaudeCodeContinue`, `ClaudeCodeResume`) in normal mode, with descriptive labels for clarity.