### PR TITLE
Using just PROJECT_CONTEXT to enable/disable AI plugins for consistency

### DIFF
--- a/lua/custom/plugins/avante.lua
+++ b/lua/custom/plugins/avante.lua
@@ -1,6 +1,6 @@
 return {
   'yetone/avante.nvim',
-  enabled = vim.fn.getenv 'NVIM_AVANTE' == 'true',
+  enabled = vim.fn.getenv 'PROJECT_CONTEXT' == 'personal',
   event = { 'BufReadPost', 'CmdlineEnter' }, -- More specific events for better lazy-loading
   version = false, -- Never set this value to "*"! Never!
   opts = {

--- a/lua/custom/plugins/copilot-chat.lua
+++ b/lua/custom/plugins/copilot-chat.lua
@@ -1,7 +1,7 @@
 return {
   {
     'CopilotC-Nvim/CopilotChat.nvim',
-    enabled = vim.fn.getenv("NVIM_COPILOT") == "true",
+    enabled = vim.fn.getenv 'PROJECT_CONTEXT' == 'personal',
     dependencies = {
       { 'zbirenbaum/copilot.lua' },
       { 'nvim-lua/plenary.nvim', branch = 'master' }, -- for curl, log and async functions

--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -1,6 +1,6 @@
 return {
   'zbirenbaum/copilot.lua',
-  enabled = vim.fn.getenv 'NVIM_COPILOT' == 'true',
+  enabled = vim.fn.getenv 'PROJECT_CONTEXT' == 'personal',
   cmd = 'Copilot',
   event = 'InsertEnter',
   config = function()


### PR DESCRIPTION
This pull request updates the logic for enabling specific plugins based on environment variables. The changes replace checks for individual plugin-specific environment variables with a unified check for the `PROJECT_CONTEXT` environment variable set to `personal`. This simplifies configuration management and ensures consistency across plugins.

### Plugin enablement logic updates:

* [`lua/custom/plugins/avante.lua`](diffhunk://#diff-269b246eb3dd31611dd7be3ecb7c8e8b79977004e863d7d50b4d16a4763118e6L3-R3): Changed the `enabled` condition from `vim.fn.getenv 'NVIM_AVANTE' == 'true'` to `vim.fn.getenv 'PROJECT_CONTEXT' == 'personal'`.
* [`lua/custom/plugins/copilot-chat.lua`](diffhunk://#diff-a7703b228d236fe67f19317d7ca2d53b8c4301b67d146d606bf8bc16e5f8c69fL4-R4): Updated the `enabled` condition from `vim.fn.getenv("NVIM_COPILOT") == "true"` to `vim.fn.getenv 'PROJECT_CONTEXT' == 'personal'`.
* [`lua/custom/plugins/copilot.lua`](diffhunk://#diff-9bcb292b7ac1268ba32febbc3c029b5b2a63545412885123d03375ecb96f0f8cL3-R3): Modified the `enabled` condition from `vim.fn.getenv 'NVIM_COPILOT' == 'true'` to `vim.fn.getenv 'PROJECT_CONTEXT' == 'personal'`.

