### PR TITLE
Adding Dbee plugin to connect to databases

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -25,6 +25,7 @@
   "mini.pick": { "branch": "main", "commit": "8521fe21df86e08d9e4b3c3f3a7d50e47954e1af" },
   "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
   "nvim-cmp": { "branch": "main", "commit": "da88697d7f45d16852c6b2769dc52387d1ddc45f" },
+  "nvim-dbee": { "branch": "master", "commit": "dda517694889a5d238d7aa407403984da9f80cc0" },
   "nvim-lspconfig": { "branch": "master", "commit": "ead0f5f342d8d323441e7d4b88f0fc436a81ad5f" },
   "nvim-tree.lua": { "branch": "master", "commit": "c988e289428d9202b28ba27479647033c7dd2956" },
   "nvim-treesitter": { "branch": "main", "commit": "6bc51d020a5e06b7e20ea82dbc47196d3d3027c7" },

--- a/lua/custom/plugins/dbee.lua
+++ b/lua/custom/plugins/dbee.lua
@@ -1,0 +1,15 @@
+return {
+  'kndndrj/nvim-dbee',
+  dependencies = {
+    'MunifTanjim/nui.nvim',
+  },
+  build = function()
+    -- Install tries to automatically detect the install method.
+    -- if it fails, try calling it with one of these parameters:
+    --    "curl", "wget", "bitsadmin", "go"
+    require('dbee').install()
+  end,
+  config = function()
+    require('dbee').setup(--[[optional config]])
+  end,
+}


### PR DESCRIPTION
This pull request adds support for the `nvim-dbee` plugin, which is a database client for Neovim. The changes ensure that the plugin and its dependency are properly installed and configured.

New plugin addition:

* Added `nvim-dbee` plugin entry to `lazy-lock.json` to manage its installation and version.
* Created a new plugin configuration file `lua/custom/plugins/dbee.lua` to set up `nvim-dbee` with its dependency `nui.nvim`, including installation and setup logic.

